### PR TITLE
Add settings, recordings_and_events api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This python library provides a client to interact with [SoraCam API](https://use
 - `get_images_exports`: Return the result of the images exports request.
 - `download_file_from_url`: Downloads a file from the specified URL and saves it to the specified
         path.
+- `get_device_recordings_and_events`: Gets the device recordings duration and events.
+- `get_settings`: Gets the settings of sora_cam.
+- `post_settings`: Sends a request to change settings of sora_cam.
 
 
 ## Installation
@@ -40,7 +43,7 @@ clinet = sc.SoraCamClient(
 device_list = client.get_devices()
 
 ```
-For more information, please see docstring in [soracam_api.py](https://github.com/soracom-labs/sora-cam-python-client/blob/main/soracam/soracam_api.py)
+For more information, please see docstring in [soracam_api.py](https://github.com/soracom-labs/sora-cam-python-client/soracam/soracom_api.py)
 
 ## Configuration
 

--- a/soracam/soracam_api.py
+++ b/soracam/soracam_api.py
@@ -14,11 +14,11 @@ from urllib.parse import unquote, urlparse
 import soracam as sc
 
 
-_DEBUG = os.environ.get('DEBUG', 'True').lower() in ['true', '1']
+_DEBUG = os.environ.get("DEBUG", "True").lower() in ["true", "1"]
 
 # log settings
-FORMAT = '%(levelname)s %(asctime)s \
-          %(funcName)s %(filename)s %(lineno)d %(message)s'
+FORMAT = "%(levelname)s %(asctime)s \
+          %(funcName)s %(filename)s %(lineno)d %(message)s"
 logging.basicConfig(format=FORMAT)
 logger = logging.getLogger(__name__)
 if _DEBUG:
@@ -26,10 +26,9 @@ if _DEBUG:
 else:
     logger.setLevel(logging.INFO)
 
-_REQUESTS_TIMEOUT = os.environ.get('REQUESTS_TIMEOUT', sc.REQUESTS_TIMEOUT)
-_MAX_API_RETRIES = os.environ.get('MAX_API_RETRIES', sc.MAX_API_RETRIES)
-_SORACOM_ENDPOINT = os.environ.get(
-    'SORACOM_ENDPOINT', sc.SORACOM_ENDPOINT)
+_REQUESTS_TIMEOUT = os.environ.get("REQUESTS_TIMEOUT", sc.REQUESTS_TIMEOUT)
+_MAX_API_RETRIES = os.environ.get("MAX_API_RETRIES", sc.MAX_API_RETRIES)
+_SORACOM_ENDPOINT = os.environ.get("SORACOM_ENDPOINT", sc.SORACOM_ENDPOINT)
 
 
 class SoraCamClient(object):
@@ -51,7 +50,7 @@ class SoraCamClient(object):
             auth_key (str): The authentication key.
         """
 
-        self.request_headers = {'Content-type': 'application/json'}
+        self.request_headers = {"Content-type": "application/json"}
         self.api_endpoint = _SORACOM_ENDPOINT % coverage_type
         self.auth_key_id = auth_key_id
         self.auth_key = auth_key
@@ -64,34 +63,34 @@ class SoraCamClient(object):
             dict: The headers to be used for authentication.
         """
 
-        url = urljoin(self.api_endpoint, 'v1/auth')
-        payload = {
-            "authKeyId": self.auth_key_id,
-            "authKey": self.auth_key
-        }
+        url = urljoin(self.api_endpoint, "v1/auth")
+        payload = {"authKeyId": self.auth_key_id, "authKey": self.auth_key}
         try:
             response = requests.post(
-                url=url, json=payload,
-                timeout=_REQUESTS_TIMEOUT)
+                url=url, json=payload, timeout=_REQUESTS_TIMEOUT
+            )
         except Exception as error:
             logger.error(f"failed to authenticate: {error}")
             raise error
         param = response.json()
         headers = {
-            'X-Soracom-API-Key': param.get('apiKey'),
-            'X-Soracom-Token': param.get('token'),
-            'accept': "application/json",
-            'Content-Type': "application/json"
+            "X-Soracom-API-Key": param.get("apiKey"),
+            "X-Soracom-Token": param.get("token"),
+            "accept": "application/json",
+            "Content-Type": "application/json",
         }
         yield headers
 
-    def _get(self, url: str, params: dict = {}) -> dict:
+    def _get(
+        self, url: str, params: dict = {}, raw: bool = False
+    ) -> dict | requests.Response:
         """
         Sends a GET request to URL.
 
         Parameters:
             url (str): The URL for the request send to.
             params (dict): The path parameters
+            raw (bool): The flag to switch return types dict or Response.
         Returns:
             dict: The response from the API returned by JSON.
 
@@ -103,10 +102,13 @@ class SoraCamClient(object):
         for _ in range(_MAX_API_RETRIES):
             try:
                 response = requests.get(
-                    url=url, headers=next(self._soracom_headers()),
-                    timeout=_REQUESTS_TIMEOUT, params=params)
+                    url=url,
+                    headers=next(self._soracom_headers()),
+                    timeout=_REQUESTS_TIMEOUT,
+                    params=params,
+                )
                 response.raise_for_status()
-                return response.json()
+                return response if raw else response.json()
             except requests.exceptions.HTTPError as err:
                 logger.error(f"get request for {url} failed: {err}")
                 last_exception = err
@@ -135,10 +137,16 @@ class SoraCamClient(object):
         for _ in range(_MAX_API_RETRIES):
             try:
                 response = requests.post(
-                    url=url, headers=next(self._soracom_headers()),
-                    json=payload, timeout=_REQUESTS_TIMEOUT)
+                    url=url,
+                    headers=next(self._soracom_headers()),
+                    json=payload,
+                    timeout=_REQUESTS_TIMEOUT,
+                )
                 response.raise_for_status()
-                return response.json()
+                try:
+                    return response.json()
+                except ValueError:
+                    return {}
             except requests.exceptions.HTTPError as err:
                 logger.error(f"post request for {url} failed: {err}")
                 last_exception = err
@@ -148,8 +156,13 @@ class SoraCamClient(object):
                     raise
         raise last_exception
 
-    def _check_export_status(self, device_id: str, export_id: str,
-                             media: str, expected: str = "completed") -> bool:
+    def _check_export_status(
+        self,
+        device_id: str,
+        export_id: str,
+        media: str,
+        expected: str = "completed",
+    ) -> bool:
         """
         Checks the export status of a device.
 
@@ -169,27 +182,30 @@ class SoraCamClient(object):
                 If checking the export status times out.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, media, "exports", export_id)
+        path = os.path.join(
+            sc.SORA_CAM_BASE_URL, device_id, media, "exports", export_id
+        )
         url = urljoin(self.api_endpoint, path)
         start_time = time.time()
         wait_time = sc.LOOP_WAITE_SECOND
-        while (time.time() - start_time < sc.WAITE_TIMEOUT):
+        while time.time() - start_time < sc.WAITE_TIMEOUT:
             response = self._get(url)
             logger.debug(f"export status: {response}")
-            status = response.get('status', '')
+            status = response.get("status", "")
             if status == expected:
                 return True
             elif status == "failed":
                 raise sc.ExportFailedError(
                     f"Export failed for device {device_id}, \
-                    export {export_id}")
+                    export {export_id}"
+                )
             if wait_time <= sc.LOOP_WAITE_MAX_SECOND:
                 wait_time += sc.LOOP_WAITE_SECOND
             time.sleep(wait_time)
         raise sc.ExportTimeoutError(
             f"Checking export status timed out \
-            for device {device_id}, export {export_id}")
+            for device {device_id}, export {export_id}"
+        )
 
     @staticmethod
     def download_file_from_url(target_url: str, target_directory: str) -> str:
@@ -215,10 +231,11 @@ class SoraCamClient(object):
         save_path = os.path.join(target_directory, filename)
         logger.debug(f"save file to: {save_path} from: {target_url}")
         try:
-            with requests.get(target_url, stream=True,
-                              timeout=_REQUESTS_TIMEOUT) as r:
+            with requests.get(
+                target_url, stream=True, timeout=_REQUESTS_TIMEOUT
+            ) as r:
                 r.raise_for_status()
-                with open(save_path, 'wb') as f:
+                with open(save_path, "wb") as f:
                     for chunk in r.iter_content(chunk_size=8192):
                         if chunk:
                             f.write(chunk)
@@ -228,8 +245,11 @@ class SoraCamClient(object):
             raise
 
     def post_images_export_requests(
-            self, device_id: str, wide_angle_correction: bool = True,
-            export_time: int = 0) -> dict:
+        self,
+        device_id: str,
+        wide_angle_correction: bool = True,
+        export_time: int = 0,
+    ) -> dict:
         """
         Sends an exporting image request from recorded video.
 
@@ -247,19 +267,17 @@ class SoraCamClient(object):
             processing the response.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, 'images/exports')
+        path = os.path.join(sc.SORA_CAM_BASE_URL, device_id, "images/exports")
         url = urljoin(self.api_endpoint, path)
         if not export_time:
             export_time = int(time.time()) * 1000
         payload = {}
-        payload['time'] = export_time
+        payload["time"] = export_time
         if wide_angle_correction:
-            payload['imageFilters'] = ["wide_angle_correction"]
+            payload["imageFilters"] = ["wide_angle_correction"]
         return self._post(url, payload)
 
-    def get_images_exports(
-            self, device_id: str, export_id: str) -> dict:
+    def get_images_exports(self, device_id: str, export_id: str) -> dict:
         """
         Return the result of the images exports request.
 
@@ -276,15 +294,14 @@ class SoraCamClient(object):
             Exception: If an error occurs while sending the GET request.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, 'images/exports', export_id)
+        path = os.path.join(
+            sc.SORA_CAM_BASE_URL, device_id, "images/exports", export_id
+        )
         url = urljoin(self.api_endpoint, path)
-        if self._check_export_status(device_id, export_id,
-                                     sc.MEDIA_IMAGE):
+        if self._check_export_status(device_id, export_id, sc.MEDIA_IMAGE):
             return self._get(url)
 
-    def get_stream(
-            self, device_id: str, from_t: int, to_t: int) -> dict:
+    def get_stream(self, device_id: str, from_t: int, to_t: int) -> dict:
         """
         Sends a get stream request from recorded video.
 
@@ -300,18 +317,15 @@ class SoraCamClient(object):
             Exception: If an error occurs while sending the GET request.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, 'stream')
+        path = os.path.join(sc.SORA_CAM_BASE_URL, device_id, "stream")
         url = urljoin(self.api_endpoint, path)
 
-        payload = {
-            "from": from_t,
-            "to": to_t
-        }
+        payload = {"from": from_t, "to": to_t}
         return self._post(url, payload)
 
     def post_videos_export_requests(
-            self, device_id: str, from_t: int, to_t: int) -> dict:
+        self, device_id: str, from_t: int, to_t: int
+    ) -> dict:
         """
         Sends an exporting video request from recorded video.
 
@@ -328,18 +342,13 @@ class SoraCamClient(object):
             Exception: If an error occurs while sending the POST request.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, 'videos/exports')
+        path = os.path.join(sc.SORA_CAM_BASE_URL, device_id, "videos/exports")
         url = urljoin(self.api_endpoint, path)
 
-        payload = {
-            "from": from_t,
-            "to": to_t
-        }
+        payload = {"from": from_t, "to": to_t}
         return self._post(url, payload)
 
-    def get_videos_exports(
-            self, device_id: str, export_id: str) -> dict:
+    def get_videos_exports(self, device_id: str, export_id: str) -> dict:
         """
         Return the result of the video exports request.
 
@@ -357,11 +366,11 @@ class SoraCamClient(object):
             Exception: If an error occurs while sending the GET request.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL,
-                            device_id, 'videos/exports', export_id)
+        path = os.path.join(
+            sc.SORA_CAM_BASE_URL, device_id, "videos/exports", export_id
+        )
         url = urljoin(self.api_endpoint, path)
-        if self._check_export_status(device_id, export_id,
-                                     sc.MEDIA_VIDEO):
+        if self._check_export_status(device_id, export_id, sc.MEDIA_VIDEO):
             return self._get(url)
 
     def get_devices(self) -> dict:
@@ -389,18 +398,40 @@ class SoraCamClient(object):
         off_line_devices = []
         device_list = self.get_devices()
         for dv in device_list:
-            if not dv.get('connected', True):
+            if not dv.get("connected", True):
                 device_status = {}
-                device_status['device_name'] = dv.get('name', None)
-                device_status['device_id'] = dv.get('deviceId', None)
-                device_status['last_connection'] = dv.get(
-                    'lastConnectedTime', None)
+                device_status["device_name"] = dv.get("name", None)
+                device_status["device_id"] = dv.get("deviceId", None)
+                device_status["last_connection"] = dv.get(
+                    "lastConnectedTime", None
+                )
                 off_line_devices.append(device_status)
         return off_line_devices
 
-    def get_devices_events(self, device_id: str = None, limit: int = 10,
-                           sort: str = 'desc', label: str = None,
-                           from_t: int = None, to_t: int = None) -> dict:
+    def fetch_paginated_data(self, url, init_params):
+        params = init_params.copy()
+        aggregated_data = []
+        while True:
+            response = self._get(url, params, True)
+            if isinstance(response.json(), list):
+                aggregated_data.extend(response.json())
+            elif isinstance(response.json(), dict):
+                aggregated_data.append(response.json())
+            next_key = response.headers.get("x-soracom-next-key")
+            if not next_key:
+                break
+            params["last_evaluated_key"] = next_key
+        return aggregated_data
+
+    def get_devices_events(
+        self,
+        device_id: str = None,
+        limit: int = 10,
+        sort: str = "desc",
+        label: str = None,
+        from_t: int = None,
+        to_t: int = None,
+    ) -> list:
         """
         Gets the events of a device.
 
@@ -419,22 +450,31 @@ class SoraCamClient(object):
             Exception: If an error occurs while sending the GET request.
         """
 
-        path = os.path.join(sc.SORA_CAM_BASE_URL, 'events') \
-            if not device_id else os.path.join(
-            sc.SORA_CAM_BASE_URL, device_id, 'events')
+        path = (
+            os.path.join(sc.SORA_CAM_BASE_URL, "events")
+            if not device_id
+            else os.path.join(sc.SORA_CAM_BASE_URL, device_id, "events")
+        )
         url = urljoin(self.api_endpoint, path)
-        params = {'limit': limit}
-        params['sort'] = sort
+        params = {"limit": limit, "sort": sort, "search_type": "or"}
         if from_t:
-            params['from'] = from_t
+            params["from"] = from_t
         if to_t:
-            params['to'] = to_t
-        params['search_type'] = 'or'
-        events = self._get(url, params)
+            params["to"] = to_t
+        # repeat if the response header
+        # contains the 'x-soracom-next-key' header.
+        all_events = self.fetch_paginated_data(url, params)
         if label:
-            return [ev for ev in events if label in ev.get(
-                'eventInfo', {}).get('atomEventV1', {}).get('type', [])]
-        return events
+            return [
+                ev
+                for ev in all_events
+                if label
+                in ev.get("eventInfo", {})
+                .get("atomEventV1", {})
+                .get("type", [])
+            ]
+        else:
+            return all_events
 
     def get_device(self, device_id=None) -> dict:
         """
@@ -450,3 +490,90 @@ class SoraCamClient(object):
         device_path = os.path.join(sc.SORA_CAM_BASE_URL, device_id)
         url = urljoin(self.api_endpoint, device_path)
         return self._get(url)
+
+    def get_device_recordings_and_events(
+        self,
+        device_id: str,
+        from_t: int = None,
+        to_t: int = None,
+        sort: str = "desc",
+    ) -> list:
+        """
+        Gets the device recordings duration and events.
+
+        Parameters:
+            device_id (str): The unique identifier for the device.
+            from_t (int): The start timestamp for the recordings_and_events.
+            to_t (int): The end timestamp for the recordings_and_events.
+            sort (str): The sort order.
+
+        Returns:
+            list: The list of recordings duration and events of the device.
+
+        Raises:
+            Exception: If an error occurs while sending the GET request.
+        """
+        path = os.path.join(
+            sc.SORA_CAM_BASE_URL, device_id, "recordings_and_events"
+        )
+        url = urljoin(self.api_endpoint, path)
+        params = {"sort": sort}
+        if from_t:
+            params["from"] = from_t
+        if to_t:
+            params["to"] = to_t
+
+        # repeat if the response header
+        # contains the 'x-soracom-next-key' header.
+        all_recordings_and_events = self.fetch_paginated_data(url, params)
+        return all_recordings_and_events
+
+    def get_settings(self, device_id: str, setting: str = "") -> dict:
+        """
+        Gets the settings of sora_cam.
+
+        Parameters:
+            device_id (str): The unique identifier for the device.
+            setting (str): Specify the kind of settings. ex: `timestamp`
+
+        Returns:
+            dict: The response from the API returned by JSON.
+
+        Raises:
+            Exception: If an error occurs while sending the GET request.
+        """
+        path_components = [
+            sc.SORA_CAM_BASE_URL,
+            device_id,
+            "atomcam",
+            "settings",
+        ]
+        if setting:
+            path_components.append(setting)
+
+        path = os.path.join(*path_components)
+        url = urljoin(self.api_endpoint, path)
+        return self._get(url)
+
+    def post_settings(
+        self, device_id: str, setting: str, payload: dict
+    ) -> dict:
+        """
+        Sends a request to change settings of sora_cam.
+
+        Parameters:
+            device_id (str): The unique identifier for the device.
+            setting (str): Specify the kind of settings. ex: `timestamp`
+
+        Returns:
+            dict: The response from the API returned by JSON.
+
+        Raises:
+            Exception: If an error occurs while sending the GET request.
+        """
+
+        path = os.path.join(
+            sc.SORA_CAM_BASE_URL, device_id, "atomcam/settings/", setting
+        )
+        url = urljoin(self.api_endpoint, path)
+        return self._post(url, payload)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import tempfile
 import pytest
 from dotenv import load_dotenv
 import soracam as sc
+import time
 
 load_dotenv()
 
@@ -19,6 +20,8 @@ _VIDEO_OFFSET = os.environ.get('VIDEO_OFFSET', 1000)
 _DEVICE_ID = os.environ.get('DEVICE_ID', '')
 
 _DEBUG = os.environ.get('DEBUG', 'True').lower() in ['true', '1']
+
+_BEFOR_ONE_WEEK_FROM_T = (int(time.time()) - (7 * 24 * 60 * 60)) * 1000
 
 # log settings
 FORMAT = '%(levelname)s %(asctime)s \

--- a/tests/test_soracam_client.py
+++ b/tests/test_soracam_client.py
@@ -9,20 +9,25 @@ import soracam as sc
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .conftest import (
-    _VIDEO_DURATION, _VIDEO_OFFSET, logger, download_file_and_check_mime_type)
+    _VIDEO_DURATION,
+    _VIDEO_OFFSET,
+    _BEFOR_ONE_WEEK_FROM_T,
+    logger,
+    download_file_and_check_mime_type,
+)
 
 
 # Mocking requests for testing
-@patch('requests.post')
+@patch("requests.post")
 def test_soracam_headers(mock_post):
     mock_post.return_value.json.return_value = {
-        'apiKey': 'test_key',
-        'token': 'test_token'
+        "apiKey": "test_key",
+        "token": "test_token",
     }
-    client = sc.SoraCamClient('jp', 'auth_key_id', 'auth_key')
+    client = sc.SoraCamClient("jp", "auth_key_id", "auth_key")
     headers = next(client._soracom_headers())
-    assert headers['X-Soracom-API-Key'] == 'test_key'
-    assert headers['X-Soracom-Token'] == 'test_token'
+    assert headers["X-Soracom-API-Key"] == "test_key"
+    assert headers["X-Soracom-Token"] == "test_token"
 
 
 def test_soracam_get_devices(sora_cam_client):
@@ -32,7 +37,7 @@ def test_soracam_get_devices(sora_cam_client):
 
 def test_soracam_get_device(sora_cam_client, soracom_device):
     device_info = sora_cam_client.get_device(soracom_device)
-    assert device_info.get('deviceId') == soracom_device
+    assert device_info.get("deviceId") == soracom_device
 
 
 def test_get_offline_devices(sora_cam_client):
@@ -40,126 +45,195 @@ def test_get_offline_devices(sora_cam_client):
     off_device_list = sora_cam_client.get_offline_devices()
     off_line = False
     for dv in device_list:
-        if not dv.get('connected', True):
+        if not dv.get("connected", True):
             off_line = True
             break
     if off_line:
-        assert len(off_device_list), \
-            "there should be no offline device"
+        assert len(off_device_list), "there should be no offline device"
     else:
-        assert not len(off_device_list), \
-            "there should be more than one offline device"
+        assert not len(
+            off_device_list
+        ), "there should be more than one offline device"
 
 
 def test_get_devices_events(sora_cam_client, soracom_device):
     # assume there are several device events,
     # otherwise the tests fails
-    device_event = sora_cam_client.get_devices_events(soracom_device)
+    device_event = sora_cam_client.get_devices_events(
+        soracom_device, limit=100
+    )
     logger.debug(f"devices events: {device_event}")
-    assert len(device_event), \
-        "there should be device_event"
+    assert len(device_event), "there should be device_event"
 
 
 def test_get_devices_events_with_label(sora_cam_client, soracom_device):
     # assume there are events with person label,
     # otherwise the tests fails
-    device_event = \
-        sora_cam_client.get_devices_events(
-            soracom_device, limit=10, label='person')
+    device_event = sora_cam_client.get_devices_events(
+        soracom_device, limit=100, label="person"
+    )
     logger.debug(f"devices events: {device_event}")
-    assert len(device_event), \
-        "there should be device_event with person"
+    assert len(device_event), "there should be device_event with person"
 
 
 def test_get_devices_events_with_from_to(sora_cam_client, soracom_device):
     # assume there are several device events,
     # otherwise the tests fails
-    from_t = 1640962800 * 1000
+    from_t = _BEFOR_ONE_WEEK_FROM_T
     to_t = int(time.time()) * 1000
     device_event = sora_cam_client.get_devices_events(
-        soracom_device, from_t=from_t, to_t=to_t, limit=3, sort='desc',
-        label='motion')
+        soracom_device,
+        from_t=from_t,
+        to_t=to_t,
+        limit=100,
+        sort="desc",
+        label="motion",
+    )
     logger.debug(f"devices events: {device_event}")
-    assert len(device_event), \
-        "there should be device_event"
+    assert len(device_event), "there should be device_event"
 
 
-def test_post_and_get_images_export_requests(
-        sora_cam_client, soracom_device):
-    res = sora_cam_client.post_images_export_requests(
-        soracom_device, True)
+def test_post_and_get_images_export_requests(sora_cam_client, soracom_device):
+    res = sora_cam_client.post_images_export_requests(soracom_device, True)
     logger.debug(f"response: {res}")
-    export_id = res.get('exportId', '')
-    assert export_id, \
-        "exportId must be included"
+    export_id = res.get("exportId", "")
+    assert export_id, "exportId must be included"
     res = sora_cam_client.get_images_exports(soracom_device, export_id)
-    assert len(res), \
-        "result must be included"
-    url = res.get('url', '')
-    assert download_file_and_check_mime_type(url, 'out.jpg'), \
-        f"failed to download from {url}"
+    assert len(res), "result must be included"
+    url = res.get("url", "")
+    assert download_file_and_check_mime_type(
+        url, "out.jpg"
+    ), f"failed to download from {url}"
 
 
-def test_post_and_get_videos_export_requests(
-        sora_cam_client, soracom_device):
-    from_t = int((time.time() - _VIDEO_DURATION - _VIDEO_OFFSET)*1000)
+def test_post_and_get_videos_export_requests(sora_cam_client, soracom_device):
+    from_t = int((time.time() - _VIDEO_DURATION - _VIDEO_OFFSET) * 1000)
     to_t = from_t + _VIDEO_DURATION
 
     res = sora_cam_client.post_videos_export_requests(
-        soracom_device, from_t, to_t)
+        soracom_device, from_t, to_t
+    )
     logger.debug(f"response: {res}")
-    export_id = res.get('exportId', '')
-    assert export_id, \
-        "exportId must be included"
+    export_id = res.get("exportId", "")
+    assert export_id, "exportId must be included"
     res = sora_cam_client.get_videos_exports(soracom_device, export_id)
-    assert len(res), \
-        "result must be included"
-    url = res.get('url', '')
-    assert download_file_and_check_mime_type(url, 'out.zip') is True, \
-        f"failed to download from {url}"
+    assert len(res), "result must be included"
+    url = res.get("url", "")
+    assert (
+        download_file_and_check_mime_type(url, "out.zip") is True
+    ), f"failed to download from {url}"
 
 
 def test_check_export_status_timeout(soracom_device):
     mock_get = mock.Mock(return_value={"status": "not completed"})
     # Use the patch method to replace _get with your mock
     with mock.patch.object(sc.SoraCamClient, "_get", new=mock_get):
-        instance = sc.SoraCamClient('jp', 'auth_key_id', 'auth_key')
+        instance = sc.SoraCamClient("jp", "auth_key_id", "auth_key")
         sc.WAITE_TIMEOUT = 1
         sc.LOOP_WAITE_TIME = 0.5
         with pytest.raises(sc.ExportTimeoutError):
             instance._check_export_status(
-                device_id=soracom_device, export_id="export",
-                media="media", expected="completed")
+                device_id=soracom_device,
+                export_id="export",
+                media="media",
+                expected="completed",
+            )
 
 
-def test_negative_check_export_status_failed(
-        sora_cam_client, soracom_device):
+def test_negative_check_export_status_failed(sora_cam_client, soracom_device):
     mock_get = mock.Mock(return_value={"status": "failed"})
     with mock.patch.object(sc.SoraCamClient, "_get", new=mock_get):
-        instance = sc.SoraCamClient('jp', 'auth_key_id', 'auth_key')
+        instance = sc.SoraCamClient("jp", "auth_key_id", "auth_key")
         with pytest.raises(sc.ExportFailedError):
             instance._check_export_status(
-                device_id=soracom_device, export_id="export",
-                media="media", expected="completed")
+                device_id=soracom_device,
+                export_id="export",
+                media="media",
+                expected="completed",
+            )
 
 
-@pytest.mark.skipif("NEGATIVE_TEST" not in os.environ, reason="NEGATIVE_TEST \
-    environment variable is not set")
+@pytest.mark.skipif(
+    "NEGATIVE_TEST" not in os.environ,
+    reason="NEGATIVE_TEST \
+    environment variable is not set",
+)
 def test_negative_post_videos_export_requests_parallel(
-        sora_cam_client, soracom_device):
-    from_t = int((time.time() - _VIDEO_DURATION - _VIDEO_OFFSET)*1000)
+    sora_cam_client, soracom_device
+):
+    from_t = int((time.time() - _VIDEO_DURATION - _VIDEO_OFFSET) * 1000)
     to_t = from_t + _VIDEO_DURATION
     export_request = (soracom_device, from_t, to_t)
     tasks = []
     for _ in range(10):
         tasks.append(export_request)
     with ThreadPoolExecutor() as executor:
-        results = [executor.submit(
-            sora_cam_client.post_videos_export_requests, *task)
-                for task in tasks]
+        results = [
+            executor.submit(sora_cam_client.post_videos_export_requests, *task)
+            for task in tasks
+        ]
         for res in as_completed(results):
             try:
-                export_id = res.get('exportId', '')
-                print('task returned: ', export_id)
+                export_id = res.get("exportId", "")
+                print("task returned: ", export_id)
             except Exception as error:
                 print(f"task generated an exception: {error}")
+
+
+def test_get_device_recordings_and_events(sora_cam_client, soracom_device):
+    res = sora_cam_client.get_device_recordings_and_events(soracom_device)
+    logger.debug(f"device recordings and events: {res}")
+    assert len(res), "failed receive recordings and events"
+
+
+def test_get_device_recordings_and_events_with_from_t(
+    sora_cam_client, soracom_device
+):
+    from_t = _BEFOR_ONE_WEEK_FROM_T
+    to_t = int(time.time()) * 1000
+    res = sora_cam_client.get_device_recordings_and_events(
+        soracom_device, from_t=from_t, to_t=to_t, sort="desc"
+    )
+    logger.debug(f"device recordings and events: {res}")
+    assert len(res), "failed receive recordings and events"
+
+
+settings_test_cases = [
+    ("logo", {"state": "off"}, {"state": "off"}),
+    ("motion_tagging", {"state": "off"}, {"state": "off"}),
+    ("night_vision", {"state": "auto"}, {"state": "auto"}),
+    ("quality", {"state": "high"}, {"state": "high"}),
+    ("rotation", {"state": 0}, {"state": 0}),
+    ("status_light", {"state": "on"}, {"state": "on"}),
+    ("timestamp", {"state": "on"}, {"state": "on"}),
+]
+
+
+@pytest.mark.parametrize(
+    "setting, payload, expected_get_response", settings_test_cases
+)
+def test_post_and_get_settings(
+    sora_cam_client, soracom_device, setting, payload, expected_get_response
+):
+    res = sora_cam_client.post_settings(soracom_device, setting, payload)
+    assert res == {}, f"Expected an empty dict, but got: {res}"
+    res = sora_cam_client.get_settings(soracom_device, setting)
+    assert (
+        res == expected_get_response
+    ), f"Expected state {expected_get_response}, but got: {res}"
+
+
+def test_get_settings_contains_keys(sora_cam_client, soracom_device):
+    res = sora_cam_client.get_settings(device_id=soracom_device)
+    logger.debug(f"device settings: {res}")
+    keys_to_check = [
+        "logo",
+        "motionTagging",
+        "nightVision",
+        "rotation",
+        "statusLight",
+        "timestamp",
+    ]
+    assert all(
+        key in res for key in keys_to_check
+    ), f"Not all expected keys are present in the res: {res}"


### PR DESCRIPTION
## change log
- change `get()` method
  - add args `raw` to switch return types `Response` or `dict`.
- change `get_devices_events()` method
  - repeat the GET request while the 'x-soracom-next-key' header is present.
- support settings api
  - `get_settings()`
  - `post_settings()`
- support recordings_and_events api
  - `get_device_recordings_and_events()`
- format `soracam/soracam_api.py`and `tests/test_soracam_client.py` using [ruff](https://astral.sh/ruff)